### PR TITLE
stratum: include is_block and block_hash in mining.submit success response

### DIFF
--- a/src/gostratum/stratum_context.go
+++ b/src/gostratum/stratum_context.go
@@ -137,6 +137,26 @@ func (sc *StratumContext) ReplySuccess(id any) error {
 	})
 }
 
+// New: success with optional block info.
+// If isBlock is true, both is_block and block_hash will be included.
+// If isBlock is false, we omit both (so legacy miners see only id/result/error).
+func (sc *StratumContext) ReplySuccessWithBlockInfo(id any, isBlock bool, blockHash string) error {
+	var ib *bool
+	var bh string
+	if isBlock {
+		ib = &isBlock
+		bh = blockHash
+	}
+	return sc.Reply(JsonRpcResponse{
+		Id:        id,
+		Result:    true,
+		Error:     nil,
+		IsBlock:   ib,
+		BlockHash: bh,
+	})
+}
+
+
 func (sc *StratumContext) ReplyStaleShare(id any) error {
 	return sc.Reply(JsonRpcResponse{
 		Id:     id,


### PR DESCRIPTION
What: Adds optional fields is_block and block_hash to the JSON-RPC success response of mining.submit when a submitted solution meets network target.

Why: Allows miners to track the exact block they found, and thus if it turns red or blue, without relying on address-wide explorer scans.

Compatibility: Keeps result=true and error=null unchanged; extra fields are additive and only present on block hits.

Minimal changes: Touches only share_handler.go and stratum_context.go; no behavior changes for non-block shares.

Tested: Verified response shape and resolvable block hash against the same HTN node via htnctl GetBlock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Success responses can now optionally include block information when a block is found, returning an “isBlock” indicator and the block hash to miners.
  - Maintains legacy behavior for non-block shares, returning unchanged success responses when no block is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->