### PR TITLE
GBT() cache implementation

### DIFF
--- a/cmd/htnbridge/config.yaml
+++ b/cmd/htnbridge/config.yaml
@@ -49,3 +49,10 @@ prom_port: :2114
 
 
 mine_when_not_synced: false
+
+# gbt_cache_ttl: how long to cache GetBlockTemplate responses per payout address.
+# Caching reduces RPC load on the node when many workers request templates
+# simultaneously after a new block notification.
+# Set to 0 (or omit) to disable caching.
+# Settings this WILL remove the miner UserAgent / work attribution in the explorer for mined blocks
+# gbt_cache_ttl: 200ms

--- a/src/htnstratum/gbtcache_test.go
+++ b/src/htnstratum/gbtcache_test.go
@@ -1,0 +1,165 @@
+package htnstratum
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Hoosat-Oy/HTND/app/appmessage"
+	"go.uber.org/zap"
+)
+
+func newTestHtnApi(ttl time.Duration) *HtnApi {
+	return &HtnApi{
+		address:       "test-address",
+		blockWaitTime: 100 * time.Millisecond,
+		logger:        zap.NewNop().Sugar(),
+		gbtCache:      make(map[string]*gbtCacheEntry),
+		gbtCacheTTL:   ttl,
+	}
+}
+
+func TestGbtCache_DisabledWhenTTLZero(t *testing.T) {
+	api := newTestHtnApi(0)
+	if api.gbtCacheTTL != 0 {
+		t.Errorf("expected gbtCacheTTL 0, got %v", api.gbtCacheTTL)
+	}
+	if len(api.gbtCache) != 0 {
+		t.Error("cache map should be empty on init")
+	}
+}
+
+func TestGbtCache_InitialisedWhenTTLSet(t *testing.T) {
+	api := newTestHtnApi(150 * time.Millisecond)
+	if api.gbtCacheTTL != 150*time.Millisecond {
+		t.Errorf("expected 150ms TTL, got %v", api.gbtCacheTTL)
+	}
+	if api.gbtCache == nil {
+		t.Error("cache map must not be nil")
+	}
+}
+
+func TestGbtCache_HitBeforeExpiry(t *testing.T) {
+	api := newTestHtnApi(1 * time.Second)
+	tmpl := &appmessage.GetBlockTemplateResponseMessage{IsSynced: true}
+
+	api.gbtCacheMu.Lock()
+	api.gbtCache["addr1"] = &gbtCacheEntry{template: tmpl, fetchedAt: time.Now()}
+	api.gbtCacheMu.Unlock()
+
+	api.gbtCacheMu.Lock()
+	entry, ok := api.gbtCache["addr1"]
+	hit := ok && time.Since(entry.fetchedAt) < api.gbtCacheTTL
+	api.gbtCacheMu.Unlock()
+
+	if !hit {
+		t.Error("expected cache hit before TTL expiry")
+	}
+	if entry.template != tmpl {
+		t.Error("cached template pointer mismatch")
+	}
+}
+
+func TestGbtCache_MissAfterExpiry(t *testing.T) {
+	api := newTestHtnApi(1 * time.Millisecond)
+	tmpl := &appmessage.GetBlockTemplateResponseMessage{IsSynced: true}
+
+	api.gbtCacheMu.Lock()
+	api.gbtCache["addr1"] = &gbtCacheEntry{template: tmpl, fetchedAt: time.Now().Add(-10 * time.Millisecond)}
+	api.gbtCacheMu.Unlock()
+
+	api.gbtCacheMu.Lock()
+	entry, ok := api.gbtCache["addr1"]
+	hit := ok && time.Since(entry.fetchedAt) < api.gbtCacheTTL
+	api.gbtCacheMu.Unlock()
+
+	if hit {
+		t.Error("expected cache miss after TTL expiry")
+	}
+}
+
+func TestGbtCache_SeparateEntriesPerAddress(t *testing.T) {
+	api := newTestHtnApi(1 * time.Second)
+	tmpl1 := &appmessage.GetBlockTemplateResponseMessage{IsSynced: true}
+	tmpl2 := &appmessage.GetBlockTemplateResponseMessage{IsSynced: false}
+
+	now := time.Now()
+	api.gbtCacheMu.Lock()
+	api.gbtCache["miner_addr"] = &gbtCacheEntry{template: tmpl1, fetchedAt: now}
+	api.gbtCache["bridge_addr"] = &gbtCacheEntry{template: tmpl2, fetchedAt: now}
+	api.gbtCacheMu.Unlock()
+
+	api.gbtCacheMu.Lock()
+	e1, ok1 := api.gbtCache["miner_addr"]
+	e2, ok2 := api.gbtCache["bridge_addr"]
+	api.gbtCacheMu.Unlock()
+
+	if !ok1 || !ok2 {
+		t.Fatal("both addresses should have cache entries")
+	}
+	if e1.template == e2.template {
+		t.Error("different addresses must not share the same cached template")
+	}
+	if e1.template != tmpl1 || e2.template != tmpl2 {
+		t.Error("cached template pointers do not match expected values")
+	}
+}
+
+func TestGbtCache_ConcurrentAccess(t *testing.T) {
+	// Verify the mutex prevents data races under concurrent reads and writes.
+	api := newTestHtnApi(500 * time.Millisecond)
+	tmpl := &appmessage.GetBlockTemplateResponseMessage{IsSynced: true}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			api.gbtCacheMu.Lock()
+			entry, ok := api.gbtCache["addr"]
+			if !ok || time.Since(entry.fetchedAt) >= api.gbtCacheTTL {
+				api.gbtCache["addr"] = &gbtCacheEntry{template: tmpl, fetchedAt: time.Now()}
+			}
+			api.gbtCacheMu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	api.gbtCacheMu.Lock()
+	_, ok := api.gbtCache["addr"]
+	api.gbtCacheMu.Unlock()
+	if !ok {
+		t.Error("cache entry should exist after concurrent writes")
+	}
+}
+
+func TestGbtCache_CleanupRemovesExpiredEntries(t *testing.T) {
+	api := newTestHtnApi(1 * time.Millisecond)
+	tmpl := &appmessage.GetBlockTemplateResponseMessage{IsSynced: true}
+
+	api.gbtCacheMu.Lock()
+	api.gbtCache["addr1"] = &gbtCacheEntry{template: tmpl, fetchedAt: time.Now().Add(-10 * time.Millisecond)}
+	api.gbtCache["addr2"] = &gbtCacheEntry{template: tmpl, fetchedAt: time.Now()}
+	api.gbtCacheMu.Unlock()
+
+	// Simulate what the cleanup goroutine does.
+	api.gbtCacheMu.Lock()
+	for addr, entry := range api.gbtCache {
+		if time.Since(entry.fetchedAt) >= api.gbtCacheTTL {
+			delete(api.gbtCache, addr)
+		}
+	}
+	api.gbtCacheMu.Unlock()
+
+	api.gbtCacheMu.Lock()
+	_, expiredGone := api.gbtCache["addr1"]
+	_, freshPresent := api.gbtCache["addr2"]
+	api.gbtCacheMu.Unlock()
+
+	if expiredGone {
+		t.Error("expired entry should have been removed by cleanup")
+	}
+	if !freshPresent {
+		t.Error("fresh entry should still be present after cleanup")
+	}
+}

--- a/src/htnstratum/htnapi.go
+++ b/src/htnstratum/htnapi.go
@@ -233,14 +233,13 @@ func (htnApi *HtnApi) GetBlockTemplate(client *gostratum.StratumContext, poll in
 			cached := entry.template
 			htnApi.gbtCacheMu.Unlock()
 
-			hits := atomic.AddUint64(&htnApi.gbtCacheHits, 1)
-			misses := atomic.LoadUint64(&htnApi.gbtCacheMisses)
-			total := hits + misses
-			if total%10 == 0 {
-				rate := (float64(hits) / float64(total)) * 100.0
-				htnApi.logger.Infof("GBT cache hit rate %.2f%% (%d/%d), ttl=%s", rate, hits, total, htnApi.gbtCacheTTL)
-			}
-
+                       	hits := atomic.AddUint64(&htnApi.gbtCacheHits, 1)
+		        misses := atomic.LoadUint64(&htnApi.gbtCacheMisses)
+		        total := hits + misses
+		        if total%1000 == 0 {
+			        rate := (float64(hits) / float64(total)) * 100.0
+			        htnApi.logger.Infof("GBT cache hit rate %.2f%% (%d/%d), ttl=%s", rate, hits, total, htnApi.gbtCacheTTL)
+		        }
 			return cached, nil
 		}
 		htnApi.gbtCacheMu.Unlock()

--- a/src/htnstratum/htnapi.go
+++ b/src/htnstratum/htnapi.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Hoosat-Oy/HTND/app/appmessage"
@@ -14,15 +16,30 @@ import (
 	"go.uber.org/zap"
 )
 
+// gbtCacheEntry holds a cached GetBlockTemplate response and the time it was fetched.
+type gbtCacheEntry struct {
+	template  *appmessage.GetBlockTemplateResponseMessage
+	fetchedAt time.Time
+}
+
 type HtnApi struct {
 	address       string
 	blockWaitTime time.Duration
 	logger        *zap.SugaredLogger
 	hoosat        *rpcclient.RPCClient
 	connected     bool
+
+	// GBT response cache (per payout address)
+	gbtCache    map[string]*gbtCacheEntry
+	gbtCacheTTL time.Duration
+	gbtCacheMu  sync.Mutex
+
+	// Stats
+	gbtCacheHits   uint64
+	gbtCacheMisses uint64
 }
 
-func NewHoosatAPI(address string, blockWaitTime time.Duration, logger *zap.SugaredLogger) (*HtnApi, error) {
+func NewHoosatAPI(address string, blockWaitTime time.Duration, logger *zap.SugaredLogger, gbtCacheTTL time.Duration) (*HtnApi, error) {
 	client, err := rpcclient.NewRPCClient(address)
 	if err != nil {
 		return nil, err
@@ -34,6 +51,8 @@ func NewHoosatAPI(address string, blockWaitTime time.Duration, logger *zap.Sugar
 		logger:        logger.With(zap.String("component", "hoosatapi:"+address)),
 		hoosat:        client,
 		connected:     true,
+		gbtCache:      make(map[string]*gbtCacheEntry),
+		gbtCacheTTL:   gbtCacheTTL,
 	}, nil
 }
 
@@ -43,6 +62,7 @@ func (htnApi *HtnApi) Start(ctx context.Context, cfg BridgeConfig, blockCb func(
 	}
 	go htnApi.startBlockTemplateListener(ctx, blockCb)
 	go htnApi.startStatsThread(ctx)
+	go htnApi.startCacheCleanupThread(ctx)
 }
 
 func (htnApi *HtnApi) startStatsThread(ctx context.Context) {
@@ -64,6 +84,31 @@ func (htnApi *HtnApi) startStatsThread(ctx context.Context) {
 				continue
 			}
 			RecordNetworkStats(response.NetworkHashesPerSecond, dagResponse.BlockCount, dagResponse.Difficulty)
+		}
+	}
+}
+
+// startCacheCleanupThread periodically evicts expired GBT cache entries so
+// the cache map does not grow unbounded when many distinct payout addresses
+// are seen over time.  It is a no-op when caching is disabled (TTL == 0).
+func (htnApi *HtnApi) startCacheCleanupThread(ctx context.Context) {
+	if htnApi.gbtCacheTTL == 0 {
+		return
+	}
+	ticker := time.NewTicker(htnApi.gbtCacheTTL * 2)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			htnApi.gbtCacheMu.Lock()
+			for addr, entry := range htnApi.gbtCache {
+				if time.Since(entry.fetchedAt) >= htnApi.gbtCacheTTL {
+					delete(htnApi.gbtCache, addr)
+				}
+			}
+			htnApi.gbtCacheMu.Unlock()
 		}
 	}
 }
@@ -164,4 +209,39 @@ func (htnApi *HtnApi) GetBlockTemplate(client *gostratum.StratumContext, poll in
 		return template, nil
 	}
 
+<<<<<<< HEAD
+=======
+	// Request block template with selected payout address, using per-address
+	// cache when gbtCacheTTL > 0 to reduce RPC load on the node.
+	// On a cache miss the lock is released before the RPC call so concurrent
+	// requests for different payout addresses proceed in parallel; only map
+	// reads/writes are protected by the mutex.
+	if htnApi.gbtCacheTTL > 0 {
+		htnApi.gbtCacheMu.Lock()
+		entry, ok := htnApi.gbtCache[payoutAddress]
+		if ok && time.Since(entry.fetchedAt) < htnApi.gbtCacheTTL {
+			cached := entry.template
+			htnApi.gbtCacheMu.Unlock()
+			return cached, nil
+		}
+		htnApi.gbtCacheMu.Unlock()
+
+		// Cache miss or expired – fetch outside the lock.
+		template, err := htnApi.hoosat.GetBlockTemplate(payoutAddress, extraData)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed fetching new block template from hoosat")
+		}
+		htnApi.gbtCacheMu.Lock()
+		htnApi.gbtCache[payoutAddress] = &gbtCacheEntry{template: template, fetchedAt: time.Now()}
+		htnApi.gbtCacheMu.Unlock()
+		return template, nil
+	}
+
+	template, err := htnApi.hoosat.GetBlockTemplate(payoutAddress, extraData)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed fetching new block template from hoosat")
+	}
+
+	return template, nil
+>>>>>>> 88a2098 (feat: add per-payout-address GBT response cache to reduce node RPC load)
 }

--- a/src/htnstratum/htnapi.go
+++ b/src/htnstratum/htnapi.go
@@ -113,6 +113,18 @@ func (htnApi *HtnApi) startCacheCleanupThread(ctx context.Context) {
 	}
 }
 
+func (htnApi *HtnApi) invalidateGBTCache() {
+	// If caching is disabled, nothing to do.
+	if htnApi.gbtCacheTTL == 0 {
+		return
+	}
+
+	htnApi.gbtCacheMu.Lock()
+	clear(htnApi.gbtCache)
+	htnApi.gbtCacheMu.Unlock()
+}
+
+
 func (htnApi *HtnApi) reconnect() error {
 	if htnApi.hoosat != nil {
 		return htnApi.hoosat.Reconnect()
@@ -123,6 +135,7 @@ func (htnApi *HtnApi) reconnect() error {
 		return err
 	}
 	htnApi.hoosat = client
+	htnApi.invalidateGBTCache()
 	return nil
 }
 
@@ -150,6 +163,7 @@ func (htnApi *HtnApi) waitForSync(verbose bool) error {
 func (htnApi *HtnApi) startBlockTemplateListener(ctx context.Context, blockReadyCb func()) {
 	blockReadyChan := make(chan bool)
 	err := htnApi.hoosat.RegisterForNewBlockTemplateNotifications(func(_ *appmessage.NewBlockTemplateNotificationMessage) {
+		htnApi.invalidateGBTCache()
 		blockReadyChan <- true
 	})
 	if err != nil {

--- a/src/htnstratum/stratum_server.go
+++ b/src/htnstratum/stratum_server.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const version = "v1.6.8"
+const version = "v1.6.9"
 const minBlockWaitTime = 100 * time.Millisecond
 
 type BridgeConfig struct {

--- a/src/htnstratum/stratum_server.go
+++ b/src/htnstratum/stratum_server.go
@@ -35,6 +35,10 @@ type BridgeConfig struct {
 	MineWhenNotSynced bool          `yaml:"mine_when_not_synced"`
 	Poll              int64         `yaml:"poll"`
 	Vote              int64         `yaml:"vote"`
+
+	// GbtCacheTTL is how long to cache GetBlockTemplate responses per payout address.
+	// A value of 0 (the default) disables caching.
+	GbtCacheTTL time.Duration `yaml:"gbt_cache_ttl"`
 }
 
 func configureZap(cfg BridgeConfig) (*zap.SugaredLogger, func()) {
@@ -68,8 +72,8 @@ func ListenAndServe(cfg BridgeConfig) error {
 		StartPromServer(logger, cfg.PromPort)
 	}
 
-	blockWaitTime := max(cfg.BlockWaitTime, minBlockWaitTime)
-	htnApi, err := NewHoosatAPI(cfg.RPCServer, blockWaitTime, logger)
+        blockWaitTime := max(cfg.BlockWaitTime, minBlockWaitTime)
+        htnApi, err := NewHoosatAPI(cfg.RPCServer, blockWaitTime, logger, cfg.GbtCacheTTL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This introduces a setting into config.yaml:

gbt_cache_ttl: 190ms

When it is enabled, the bridge will stop populating extraData with specific miner user agent, version, and workername information. Instead it will set extraData to extraData = fmt.Sprintf(`Mined via htn-stratum-bridge version %s`, version)

This will mean that the cool attributions available in the explorer will be gone, and that is sad.

BUT

If you set this TTL, then it will will result in a ~50% hit rate on the getBlockTemplate cache, massively reducing RPC calls to the node.

We considered invalidating the GBT cache every time we get a notify from the node, but this happens too often, not just for newTip, and has no meta data to tell us WHEN to consider we're on a new block. I guess it will take some tuning to work out the sensible value for the GBT cache TTL, but 190ms seems like a sensible starting point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced configurable block template caching with adjustable TTL per payout address to improve performance. Cache is disabled when TTL is set to 0 or omitted.

* **Tests**
  * Added comprehensive test coverage for cache behavior including hit/miss scenarios, expiry handling, thread-safe concurrent access, and cleanup operations.

* **Chores**
  * Version bumped to v1.6.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->