### PR TITLE
Use atomic disconnect state

### DIFF
--- a/src/gostratum/stratum_context.go
+++ b/src/gostratum/stratum_context.go
@@ -22,7 +22,7 @@ type StratumContext struct {
 	Id            int32
 	Logger        *zap.Logger
 	connection    net.Conn
-	disconnecting bool
+	disconnecting atomic.Bool
 	onDisconnect  chan *StratumContext
 	State         any // gross, but go generics aren't mature enough this can be typed 😭
 	writeLock     int32
@@ -39,7 +39,7 @@ type ContextSummary struct {
 var ErrorDisconnected = fmt.Errorf("disconnecting")
 
 func (sc *StratumContext) Connected() bool {
-	return !sc.disconnecting
+	return !sc.disconnecting.Load()
 }
 
 func (sc *StratumContext) Summary() ContextSummary {
@@ -71,7 +71,7 @@ func (sc *StratumContext) String() string {
 }
 
 func (sc *StratumContext) Reply(response JsonRpcResponse) error {
-	if sc.disconnecting {
+	if sc.disconnecting.Load() {
 		return ErrorDisconnected
 	}
 	encoded, err := json.Marshal(response)
@@ -83,7 +83,7 @@ func (sc *StratumContext) Reply(response JsonRpcResponse) error {
 }
 
 func (sc *StratumContext) Send(event JsonRpcEvent) error {
-	if sc.disconnecting {
+	if sc.disconnecting.Load() {
 		return ErrorDisconnected
 	}
 	encoded, err := json.Marshal(event)
@@ -186,13 +186,14 @@ func (sc *StratumContext) ReplyLowDiffShare(id any) error {
 }
 
 func (sc *StratumContext) Disconnect() {
-	if !sc.disconnecting {
+	if sc.disconnecting.CompareAndSwap(false, true) {
 		sc.Logger.Info("disconnecting")
-		sc.disconnecting = true
 		if sc.connection != nil {
 			sc.connection.Close()
 		}
-		sc.onDisconnect <- sc
+		if sc.onDisconnect != nil {
+			sc.onDisconnect <- sc
+		}
 	}
 }
 

--- a/src/gostratum/stratum_test.go
+++ b/src/gostratum/stratum_test.go
@@ -3,6 +3,7 @@ package gostratum
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -97,5 +98,41 @@ func TestWalletValidation(t *testing.T) {
 		if cleaned != v.expected {
 			t.Fatalf("expected %s, got %s", v.expected, cleaned)
 		}
+	}
+}
+
+func TestSendReturnsDisconnectedAfterDisconnect(t *testing.T) {
+	logger := testLogger()
+	ctx, _ := NewMockContext(context.Background(), logger, nil)
+
+	ctx.Disconnect()
+
+	err := ctx.Send(JsonRpcEvent{
+		Version: "2.0",
+		Method:  "mining.set_difficulty",
+		Params:  []any{1.0},
+	})
+	if !errors.Is(err, ErrorDisconnected) {
+		t.Fatalf("expected ErrorDisconnected, got %v", err)
+	}
+	if ctx.Connected() {
+		t.Fatal("expected disconnected context")
+	}
+}
+
+func TestDisconnectIsIdempotent(t *testing.T) {
+	ctx := &StratumContext{
+		Logger:       testLogger(),
+		onDisconnect: make(chan *StratumContext, 2),
+	}
+
+	ctx.Disconnect()
+	ctx.Disconnect()
+
+	if got := len(ctx.onDisconnect); got != 1 {
+		t.Fatalf("expected one disconnect notification, got %d", got)
+	}
+	if ctx.Connected() {
+		t.Fatal("expected disconnected context")
 	}
 }

--- a/src/htnstratum/client_handler.go
+++ b/src/htnstratum/client_handler.go
@@ -230,6 +230,10 @@ func sendClientDiff(client *gostratum.StratumContext, state *MiningState) {
 		Method:  "mining.set_difficulty",
 		Params:  []any{state.stratumDiff.diffValue},
 	}); err != nil {
+		if errors.Is(err, gostratum.ErrorDisconnected) {
+			RecordWorkerError(client.WalletAddr, ErrDisconnected)
+			return
+		}
 		RecordWorkerError(client.WalletAddr, ErrFailedSetDiff)
 		client.Logger.Debug(errors.Wrap(err, "failed sending difficulty").Error())
 		return


### PR DESCRIPTION
The state connection for clients was racing - which sometimes caused floods of "failed to send difficulty, disconnecting client" log spam - and of course miners got disconnected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved concurrency safety for client disconnection handling
  * Enhanced reliability and error reporting when clients disconnect
  * Optimized error detection and recovery in client communication

* **Tests**
  * Added validation tests for disconnect scenarios and idempotency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->